### PR TITLE
Use Ethers for keccak256 hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bulk Keccak256
 
-This Next.js app hashes each line of input text individually using SHA3-256 from Node's crypto library and returns the first 4 bytes (8 hex characters).
+This Next.js app hashes each line of input text individually using `keccak256`
+from the Ethers library and returns the first 4 bytes (8 hex characters, including the `0x` prefix).
 
 ## Usage
 
@@ -14,4 +15,4 @@ This Next.js app hashes each line of input text individually using SHA3-256 from
    ```
 3. Open `http://localhost:3000` in your browser and paste lines of text to hash.
 
-**Note:** The hashing uses `sha3-256` from Node's crypto, which may not be fully compatible with Ethereum's Keccak-256.
+**Note:** Hashing uses Ethereum's Keccak-256 implementation via the Ethers library.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "ethers": "latest"
   },
   "devDependencies": {
     "typescript": "^5.2.0",

--- a/pages/api/hash.ts
+++ b/pages/api/hash.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import crypto from 'crypto';
+import { keccak256, toUtf8Bytes } from 'ethers';
 
 type Data = { hashes: string[] };
 
@@ -15,8 +15,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse<Data>)
   }
   const lines = text.split(/\r?\n/).filter(Boolean);
   const hashes = lines.map(line => {
-    const digest = crypto.createHash('sha3-256').update(line).digest('hex');
-    return digest.slice(0, 8);
+    const selector = keccak256(toUtf8Bytes(line)).slice(0, 10);
+    return selector;
   });
   res.status(200).json({ hashes });
 }


### PR DESCRIPTION
## Summary
- use `keccak256` from Ethers when hashing lines
- add `ethers` dependency
- document keccak256 usage in README

## Testing
- `npm test` *(fails: Missing script)*